### PR TITLE
Upgrade to support Elm 0.17

### DIFF
--- a/examples/project/elm-package.json
+++ b/examples/project/elm-package.json
@@ -1,17 +1,15 @@
 {
-    "version": "1.0.0",
-    "summary": "Multiple main module Example",
-    "repository": "https://github.com/joeandaverde/elm-project-loader-example.git",
-    "license": "MIT",
-    "source-directories": [
-        "./src/elm"
-    ],
-    "exposed-modules": [],
-    "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0",
-        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
-        "evancz/start-app": "2.0.2 <= v < 3.0.0",
-        "evancz/elm-effects": "2.0.1 <= v < 3.0.0"
-    },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+   "version": "1.0.0",
+   "summary": "Multiple main module Example",
+   "repository": "https://github.com/joeandaverde/elm-project-loader-example.git",
+   "license": "MIT",
+   "source-directories": [
+      "./src/elm"
+   ],
+   "exposed-modules": [],
+   "dependencies": {
+      "elm-lang/core": "4.0.0 <= v < 5.0.0",
+      "elm-lang/html": "1.0.0 <= v < 2.0.0"
+   },
+   "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/examples/project/index.html
+++ b/examples/project/index.html
@@ -1,0 +1,17 @@
+<!-- index.html -->
+<!DOCTYPE html>
+<html>
+   <head>
+      <meta charset="utf-8" />
+      <title>Elm Example</title>
+   </head>
+   <body>
+      <h1>WidgetA</h1>
+      <div id="widgetA"></div>
+
+      <h1>WidgetB</h1>
+      <div id="widgetB"></div>
+
+      <script src="dist/index.js"></script>
+   </body>
+</html>

--- a/examples/project/src/elm/Components/WidgetA/Main.elm
+++ b/examples/project/src/elm/Components/WidgetA/Main.elm
@@ -1,30 +1,15 @@
-module Components.WidgetA.Main (..) where
+module Components.WidgetA.Main exposing (..)
 
-import StartApp
-import Effects exposing (Effects)
-import Signal exposing (Signal)
-import Html exposing (Html)
+import Html.App as Html
 import Components.WidgetA.Model exposing (Model, initialModel)
 import Components.WidgetA.View exposing (view)
 import Components.WidgetA.Update as Update exposing (update)
 
 
-main : Signal Html
 main =
-  app.html
-
-
-
-app : StartApp.App Model
-app =
-  StartApp.start
-    { init = ( initialModel, Effects.none )
-    , view = view
-    , update = update
-    , inputs = [ messages.signal ]
-    }
-
-
-messages : Signal.Mailbox Update.Action
-messages =
-  Signal.mailbox Update.NoOp
+    Html.program
+        { init = ( initialModel, Cmd.none )
+        , update = update
+        , view = view
+        , subscriptions = \_ -> Sub.none
+        }

--- a/examples/project/src/elm/Components/WidgetA/Model.elm
+++ b/examples/project/src/elm/Components/WidgetA/Model.elm
@@ -1,10 +1,10 @@
-module Components.WidgetA.Model (..) where
+module Components.WidgetA.Model exposing (..)
 
 
 type alias Model =
-  Int
+    Int
 
 
 initialModel : Model
 initialModel =
-  0
+    0

--- a/examples/project/src/elm/Components/WidgetA/Update.elm
+++ b/examples/project/src/elm/Components/WidgetA/Update.elm
@@ -1,13 +1,22 @@
-module Components.WidgetA.Update where
+module Components.WidgetA.Update exposing (..)
 
-import Effects exposing (Effects)
 import Components.WidgetA.Model exposing (..)
 
-type Action = Increment | Decrement | NoOp
 
-update : Action -> Model -> (Model, Effects Action)
-update action model =
-  case action of
-    Increment -> (model + 1, Effects.none)
-    Decrement -> (model - 1, Effects.none)
-    NoOp -> (model, Effects.none)
+type Msg
+    = Increment
+    | Decrement
+    | NoOp
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Increment ->
+            ( model + 1, Cmd.none )
+
+        Decrement ->
+            ( model - 1, Cmd.none )
+
+        NoOp ->
+            ( model, Cmd.none )

--- a/examples/project/src/elm/Components/WidgetA/View.elm
+++ b/examples/project/src/elm/Components/WidgetA/View.elm
@@ -1,17 +1,15 @@
-module Components.WidgetA.View (..) where
+module Components.WidgetA.View exposing (..)
 
 import Components.WidgetA.Model exposing (..)
 import Components.WidgetA.Update exposing (..)
-import Signal exposing (Address)
 import Html exposing (Html, div, button, text)
 import Html.Events exposing (onClick)
 
 
-view : Address Action -> Model -> Html
-view address model =
-  div
-    []
-    [ button [ onClick address Decrement ] [ text "-" ]
-    , div [] [ text (toString model) ]
-    , button [ onClick address Increment ] [ text "+" ]
-    ]
+view : Model -> Html Msg
+view model =
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]

--- a/examples/project/src/elm/Components/WidgetB/Main.elm
+++ b/examples/project/src/elm/Components/WidgetB/Main.elm
@@ -1,29 +1,16 @@
-module Components.WidgetB.Main (..) where
+module Components.WidgetB.Main exposing (..)
 
-import StartApp
-import Effects exposing (Effects)
-import Signal exposing (Signal)
+import Html.App as Html
 import Html exposing (Html)
 import Components.WidgetB.Model exposing (Model, initialModel)
 import Components.WidgetB.View exposing (view)
 import Components.WidgetB.Update as Update exposing (update)
 
 
-main : Signal Html
 main =
-  app.html
-
-
-app : StartApp.App Model
-app =
-  StartApp.start
-    { init = ( initialModel, Effects.none )
-    , view = view
-    , update = update
-    , inputs = [ messages.signal ]
-    }
-
-
-messages : Signal.Mailbox Update.Action
-messages =
-  Signal.mailbox Update.NoOp
+    Html.program
+        { init = ( initialModel, Cmd.none )
+        , update = update
+        , view = view
+        , subscriptions = \_ -> Sub.none
+        }

--- a/examples/project/src/elm/Components/WidgetB/Model.elm
+++ b/examples/project/src/elm/Components/WidgetB/Model.elm
@@ -1,10 +1,10 @@
-module Components.WidgetB.Model (..) where
+module Components.WidgetB.Model exposing (..)
 
 
 type alias Model =
-  Int
+    Int
 
 
 initialModel : Model
 initialModel =
-  0
+    0

--- a/examples/project/src/elm/Components/WidgetB/Update.elm
+++ b/examples/project/src/elm/Components/WidgetB/Update.elm
@@ -1,13 +1,22 @@
-module Components.WidgetB.Update where
+module Components.WidgetB.Update exposing (..)
 
-import Effects exposing (Effects)
 import Components.WidgetB.Model exposing (..)
 
-type Action = Increment | Decrement | NoOp
 
-update : Action -> Model -> (Model, Effects Action)
-update action model =
-  case action of
-    Increment -> (model + 1, Effects.none)
-    Decrement -> (model - 1, Effects.none)
-    NoOp -> (model, Effects.none)
+type Msg
+    = Increment
+    | Decrement
+    | NoOp
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Increment ->
+            ( model + 2, Cmd.none )
+
+        Decrement ->
+            ( model - 2, Cmd.none )
+
+        NoOp ->
+            ( model, Cmd.none )

--- a/examples/project/src/elm/Components/WidgetB/View.elm
+++ b/examples/project/src/elm/Components/WidgetB/View.elm
@@ -1,17 +1,15 @@
-module Components.WidgetB.View (..) where
+module Components.WidgetB.View exposing (..)
 
 import Components.WidgetB.Model exposing (..)
 import Components.WidgetB.Update exposing (..)
-import Signal exposing (Address)
 import Html exposing (Html, div, button, text)
 import Html.Events exposing (onClick)
 
 
-view : Address Action -> Model -> Html
-view address model =
-  div
-    []
-    [ button [ onClick address Decrement ] [ text "-" ]
-    , div [] [ text (toString model) ]
-    , button [ onClick address Increment ] [ text "+" ]
-    ]
+view : Model -> Html Msg
+view model =
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]

--- a/examples/project/src/index.js
+++ b/examples/project/src/index.js
@@ -1,3 +1,6 @@
 const Elm = require('../my-app.elmproj')
 
 console.log(Elm)
+
+Elm.Components.WidgetA.Main.embed(document.getElementById('widgetA'))
+Elm.Components.WidgetB.Main.embed(document.getElementById('widgetB'))

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const _ = require('lodash')
 const Path = require('path')
 const LoaderUtils = require('loader-utils')
-const NodeElmCompiler = require('node-elm-compiler')
 const Fs = require('fs')
 const GlobFs = require('glob-fs')
 const Spawn = require('child_process').spawn
@@ -229,7 +228,7 @@ module.exports = function (source) {
          .then(loaded => {
             _.map(loaded.dependencies, d => this.addDependency(d))
 
-            callback(null, [loaded.output, 'module.exports = Elm;'].join('\n'))
+            callback(null, loaded.output)
          })
       })
    })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-project-loader",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Webpack Loader for Elm Projects.",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,6 @@
     "glob-fs": "^0.1.6",
     "loader-utils": "^0.2.12",
     "lodash": "^4.6.1",
-    "node-elm-compiler": "^3.0.0",
     "temp": "^0.8.3"
   }
 }


### PR DESCRIPTION
* Remove module.exports append (see
https://github.com/rtfeldman/elm-webpack-loader/commit/4c28894ce352ab317
83a2206f59af0832d692655)
* Upgrade example to elm 0.17
* Add index.html and load both widgets in example
* Remove node-elm-compiler dependency since it is not used.
* WidgetB in example counts by 2 so that it is noticeably different
than WidgetA